### PR TITLE
Translate codebase to English

### DIFF
--- a/core/epub_builder.py
+++ b/core/epub_builder.py
@@ -34,7 +34,7 @@ def _load_chapter_content(file_path: str, chapter_title: str, chapter_uid: str) 
             title=chapter_title,
             file_name=f'{_sanitize_id(chapter_uid)}.xhtml', # Use .xhtml extension
             uid=chapter_uid,
-            lang='pt-BR' # Assuming Portuguese, can be parameterized
+            lang='en' # Assuming the content is in English, can be parameterized
         )
         chapter_item.content = html_content
         return chapter_item
@@ -103,6 +103,7 @@ def build_epubs_for_story(input_folder: str, output_folder: str, chapters_per_ep
                 h1_title_tag = soup_title.find('h1')
                 if h1_title_tag and h1_title_tag.string:
                     extracted_title = h1_title_tag.string.strip()
+                    # Regex to remove "Chapter X: " or "Capítulo X: " prefixes from H1 tag for a cleaner story title
                     extracted_title = re.sub(r"^(Chapter|Capítulo)\s*\d+\s*[:\-]\s*", "", extracted_title, flags=re.IGNORECASE).strip()
                     if extracted_title:
                         effective_story_title = extracted_title
@@ -130,7 +131,7 @@ def build_epubs_for_story(input_folder: str, output_folder: str, chapters_per_ep
         if not current_batch_files:
             continue
 
-        part_suffix_display = f" (Parte {i + 1})" if num_epubs > 1 else ""
+        part_suffix_display = f" (Part {i + 1})" if num_epubs > 1 else ""
         current_epub_title = f"{effective_story_title}{part_suffix_display}"
 
         epub_filename_base = _sanitize_id(effective_story_title if effective_story_title and effective_story_title != "Unknown Story" else "story")
@@ -145,10 +146,10 @@ def build_epubs_for_story(input_folder: str, output_folder: str, chapters_per_ep
         book.set_identifier(f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_DNS, current_epub_title)}")
         book.set_title(current_epub_title)
         book.add_author(author_name)
-        book.set_language('pt-BR')
+        book.set_language('en')
         book.add_metadata('DC', 'publisher', 'Royal Road Archiver')
         book.add_metadata('DC', 'date', datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), {'id': 'pubdate'})
-        book.add_metadata('DC', 'description', f"Arquivado de Royal Road - {effective_story_title}{part_suffix_display}")
+        book.add_metadata('DC', 'description', f"Archived from Royal Road - {effective_story_title}{part_suffix_display}")
 
 
         style_content = """
@@ -171,7 +172,7 @@ img, svg { max-width: 100%; height: auto; display: block; margin: 1em auto; bord
         for chap_idx, chapter_file_name in enumerate(current_batch_files):
             full_chapter_path = os.path.join(input_folder, chapter_file_name)
             
-            chapter_display_title_from_h1 = f"Capítulo {start_index + chap_idx + 1}" # Fallback
+            chapter_display_title_from_h1 = f"Chapter {start_index + chap_idx + 1}" # Fallback
             try:
                 with open(full_chapter_path, 'r', encoding='utf-8') as f_chap:
                     chap_soup = BeautifulSoup(f_chap.read(), 'html.parser')

--- a/core/processor.py
+++ b/core/processor.py
@@ -47,7 +47,7 @@ def _clean_and_extract_text(soup_object: BeautifulSoup, file_path: str) -> str:
             # if body_tag:
             #    content_div = body_tag
             # else:
-            return "<p>Conteúdo principal não encontrado no arquivo processado.</p>"
+            return "<p>Main content not found in the processed file.</p>"
 
 
     for script_tag in content_div.find_all('script'):
@@ -146,10 +146,10 @@ def process_story_chapters(input_story_folder: str, target_output_folder_for_sto
 
         cleaned_html_content = _clean_and_extract_text(soup, raw_file_path)
 
-        if not cleaned_html_content or cleaned_html_content.strip() == "<p>Conteúdo principal não encontrado no arquivo processado.</p>" or cleaned_html_content.strip() == "<p>Error: BeautifulSoup object was None.</p>":
+        if not cleaned_html_content or cleaned_html_content.strip() == "<p>Main content not found in the processed file.</p>" or cleaned_html_content.strip() == "<p>Error: BeautifulSoup object was None.</p>":
             print(f"   WARNING: No valid content extracted for {filename}. Output might be minimal or contain error message.")
             # Optionally, skip saving this file if content is just an error message
-            if "Conteúdo principal não encontrado" in cleaned_html_content or "Error: BeautifulSoup object was None" in cleaned_html_content:
+            if "Main content not found" in cleaned_html_content or "Error: BeautifulSoup object was None" in cleaned_html_content: # Updated to check for English error
                 print(f"   Skipping save for {filename} due to critical content extraction error.")
                 continue
 
@@ -160,7 +160,7 @@ def process_story_chapters(input_story_folder: str, target_output_folder_for_sto
         try:
             # Create a minimal valid HTML5 document for each cleaned chapter.
             final_html_to_save = f"""<!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>{chapter_display_title}</title>
@@ -243,7 +243,7 @@ if __name__ == '__main__':
 </body>
 </html>"""
 
-    dummy_file_path = os.path.join(test_input_story_folder, "capitulo_001_test_chapter.html")
+    dummy_file_path = os.path.join(test_input_story_folder, "chapter_001_test_chapter.html") # Changed "capitulo" to "chapter"
     with open(dummy_file_path, 'w', encoding='utf-8') as f:
         f.write(dummy_html_file_content)
     print(f"Created dummy chapter: {dummy_file_path}")

--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ import re
 import typer
 import os
 import traceback
-# Adicionar import para a nova função no crawler
+import time
+# Add import for the new function in the crawler
 from core.crawler import download_story, fetch_story_metadata_and_first_chapter
 from core.processor import process_story_chapters
 from core.epub_builder import build_epubs_for_story
@@ -10,7 +11,7 @@ from core.epub_builder import build_epubs_for_story
 app = typer.Typer(help="CLI for downloading and processing stories from Royal Road.", no_args_is_help=True)
 
 def is_overview_url(url: str) -> bool:
-    """Verifica se a URL é provavelmente uma página de visão geral (não contém /chapter/)."""
+    """Checks if the URL is likely an overview page (does not contain /chapter/)."""
     return "/chapter/" not in url and "/fiction/" in url
 
 @app.command(name="crawl")
@@ -27,64 +28,64 @@ def crawl_story_command(
     Downloads a story from Royal Road chapter by chapter as raw HTML files.
     Can start from a story overview page or a direct first chapter URL.
     """
-    typer.echo(f"Iniciando download para URL: {story_url}")
+    typer.echo(f"Starting download for URL: {story_url}")
     abs_output_folder = os.path.abspath(output_folder)
 
     if not os.path.exists(abs_output_folder):
         try:
             os.makedirs(abs_output_folder, exist_ok=True)
-            typer.echo(f"Pasta base de saída para downloads criada/confirmada: {abs_output_folder}")
+            typer.echo(f"Base output folder for downloads created/confirmed: {abs_output_folder}")
         except OSError as e:
-            typer.secho(f"Erro ao criar pasta base de saída '{abs_output_folder}': {e}", fg=typer.colors.RED)
+            typer.secho(f"Error creating base output folder '{abs_output_folder}': {e}", fg=typer.colors.RED)
             raise typer.Exit(code=1)
     else:
-        typer.echo(f"Usando pasta base de saída existente para downloads: {abs_output_folder}")
+        typer.echo(f"Using existing base output folder for downloads: {abs_output_folder}")
 
     first_chapter_to_crawl = story_url
     story_slug_for_folder = None
 
     if is_overview_url(story_url):
-        typer.echo("URL detectada como página de visão geral. Buscando metadados...")
+        typer.echo("URL detected as overview page. Fetching metadata...")
         metadata = fetch_story_metadata_and_first_chapter(story_url)
         if not metadata or not metadata.get('first_chapter_url'):
-            typer.secho("Falha ao obter metadados ou URL do primeiro capítulo da página de visão geral.", fg=typer.colors.RED)
+            typer.secho("Failed to get metadata or first chapter URL from overview page.", fg=typer.colors.RED)
             raise typer.Exit(code=1)
         first_chapter_to_crawl = metadata['first_chapter_url']
-        story_slug_for_folder = metadata.get('story_slug') # Usará o slug para nomear a pasta
-        typer.echo(f"Primeiro capítulo encontrado: {first_chapter_to_crawl}")
+        story_slug_for_folder = metadata.get('story_slug') # Will use the slug to name the folder
+        typer.echo(f"First chapter found: {first_chapter_to_crawl}")
         if story_slug_for_folder:
-            typer.echo(f"Slug da história para nome da pasta: {story_slug_for_folder}")
+            typer.echo(f"Story slug for folder name: {story_slug_for_folder}")
     else:
-        typer.echo("URL detectada como página de capítulo.")
-        # Tenta extrair o slug da URL do capítulo para nome da pasta
+        typer.echo("URL detected as chapter page.")
+        # Tries to extract the slug from the chapter URL for the folder name
         try:
             story_slug_for_folder = story_url.split('/fiction/')[1].split('/')[1]
             story_slug_for_folder = re.sub(r'[\\/*?:"<>|]', "", story_slug_for_folder)
             story_slug_for_folder = re.sub(r'\s+', '_', story_slug_for_folder)[:100]
-            typer.echo(f"Slug inferido da URL do capítulo: {story_slug_for_folder}")
+            typer.echo(f"Inferred slug from chapter URL: {story_slug_for_folder}")
         except IndexError:
-            typer.echo("Não foi possível inferir o slug da URL do capítulo. O nome da pasta pode ser genérico.")
+            typer.echo("Could not infer slug from chapter URL. Folder name may be generic.")
 
 
     try:
-        # download_story agora espera a pasta base (abs_output_folder) e o slug_override
-        # Ele criará abs_output_folder/story_slug_for_folder
+        # download_story now expects the base folder (abs_output_folder) and slug_override
+        # It will create abs_output_folder/story_slug_for_folder
         downloaded_story_path = download_story(first_chapter_to_crawl, abs_output_folder, story_slug_override=story_slug_for_folder)
         if downloaded_story_path:
-            typer.secho(f"\nDownload dos arquivos HTML brutos concluído com sucesso em: {downloaded_story_path}", fg=typer.colors.GREEN)
+            typer.secho(f"\nDownload of raw HTML files completed successfully at: {downloaded_story_path}", fg=typer.colors.GREEN)
         else:
-            typer.secho("\nDownload parece ter falhado ou não retornou um caminho.", fg=typer.colors.RED)
+            typer.secho("\nDownload seems to have failed or did not return a path.", fg=typer.colors.RED)
             raise typer.Exit(code=1)
 
     except ImportError:
-         typer.secho("Erro Crítico: Não foi possível importar 'download_story' ou 'fetch_story_metadata_and_first_chapter' de 'core.crawler'. Verifique o arquivo e a estrutura do projeto.", fg=typer.colors.RED)
+         typer.secho("Critical Error: Could not import 'download_story' or 'fetch_story_metadata_and_first_chapter' from 'core.crawler'. Check the file and project structure.", fg=typer.colors.RED)
          raise typer.Exit(code=1)
     except Exception as e:
-        typer.secho(f"\nOcorreu um erro durante o download: {e}", fg=typer.colors.RED)
+        typer.secho(f"\nAn error occurred during download: {e}", fg=typer.colors.RED)
         typer.echo(traceback.format_exc())
         raise typer.Exit(code=1)
 
-# ... (comando process inalterado)
+# ... (process command unchanged)
 @app.command(name="process")
 def process_story_command(
     input_story_folder: str = typer.Argument(..., help="Path to the folder containing the raw HTML chapters of a single story (e.g., downloaded_stories/story-slug)."),
@@ -108,7 +109,7 @@ def process_story_command(
         typer.secho(f"Error: Input story folder '{abs_input_story_folder}' not found or is not a directory.", fg=typer.colors.RED)
         raise typer.Exit(code=1)
 
-    # O nome da subpasta em processed_stories será o mesmo que em downloaded_stories
+    # The subfolder name in processed_stories will be the same as in downloaded_stories
     story_slug_for_processed = os.path.basename(abs_input_story_folder)
     specific_output_folder = os.path.join(abs_output_base_folder, story_slug_for_processed)
 
@@ -124,10 +125,10 @@ def process_story_command(
         typer.echo(f"Using existing specific output folder for processed files: {specific_output_folder}")
 
     try:
-        # Passa a pasta específica onde os capítulos processados da história devem ir
+        # Passes the specific folder where the processed story chapters should go
         process_story_chapters(abs_input_story_folder, specific_output_folder)
         typer.secho(f"\nProcessing of story chapters concluded successfully! Output in: {specific_output_folder}", fg=typer.colors.GREEN)
-        return specific_output_folder # Retorna o caminho para uso no full-process
+        return specific_output_folder # Returns the path for use in full-process
     except ImportError:
          typer.secho("Critical Error: Could not import 'process_story_chapters' from 'core.processor'. Check file and project structure.", fg=typer.colors.RED)
          raise typer.Exit(code=1)
@@ -137,7 +138,7 @@ def process_story_command(
         raise typer.Exit(code=1)
 
 
-# ... (comando build-epub inalterado)
+# ... (build-epub command unchanged)
 @app.command(name="build-epub")
 def build_epub_command(
     input_processed_folder: str = typer.Argument(..., help="Path to the folder containing the CLEANED HTML chapters of a single story (e.g., processed_stories/story-slug)."),
@@ -151,7 +152,7 @@ def build_epub_command(
         50,
         "--chapters-per-epub",
         "-c",
-        min=0, # 0 para um único EPUB com todos os capítulos
+        min=0, # 0 for a single EPUB with all chapters
         help="Number of chapters to include in each EPUB file. Set to 0 for a single EPUB."
     ),
     author_name: str = typer.Option(
@@ -189,18 +190,18 @@ def build_epub_command(
     else:
         typer.echo(f"Using existing base output folder for EPUBs: {abs_output_epub_folder}")
 
-    # Se chapters_per_epub for 0, passa um número muito grande para ebooklib fazer um só.
-    # A lógica interna de build_epubs_for_story já trata isso se chapters_per_epub for grande.
+    # If chapters_per_epub is 0, pass a very large number for ebooklib to make just one.
+    # The internal logic of build_epubs_for_story already handles this if chapters_per_epub is large.
     effective_chapters_per_epub = chapters_per_epub if chapters_per_epub > 0 else 999999
 
 
     try:
         build_epubs_for_story(
-            input_folder=abs_input_processed_folder, # Esta é a pasta específica da história processada
-            output_folder=abs_output_epub_folder,   # EPUBs são salvos diretamente aqui
+            input_folder=abs_input_processed_folder, # This is the specific folder for the processed story
+            output_folder=abs_output_epub_folder,   # EPUBs are saved directly here
             chapters_per_epub=effective_chapters_per_epub,
             author_name=author_name,
-            story_title=story_title # O título da história já deve estar correto aqui
+            story_title=story_title # The story title should already be correct here
         )
         typer.secho(f"\nEPUB generation concluded successfully! Files in {abs_output_epub_folder}", fg=typer.colors.GREEN)
     except ImportError:
@@ -229,13 +230,13 @@ def full_process_command(
         help="Number of chapters to include in each EPUB file. Set to 0 for a single EPUB."
     ),
     author_name_param: str = typer.Option(
-        None, # Default para None para que possamos saber se foi fornecido
+        None, # Default to None so we can know if it was provided
         "--author",
         "-a",
         help="Author name for EPUB metadata. If not provided and fetching from overview, uses that."
     ),
     story_title_param: str = typer.Option(
-        None, # Default para None
+        None, # Default to None
         "--title",
         "-t",
         help="Story title for EPUB metadata. If not provided and fetching from overview, uses that."
@@ -255,150 +256,150 @@ def full_process_command(
         if not os.path.exists(abs_folder):
             try:
                 os.makedirs(abs_folder, exist_ok=True)
-                typer.echo(f"Pasta base criada/confirmada: {abs_folder}")
+                typer.echo(f"Base folder created/confirmed: {abs_folder}")
             except OSError as e:
-                typer.secho(f"Erro ao criar pasta base '{abs_folder}': {e}", fg=typer.colors.RED)
+                typer.secho(f"Error creating base folder '{abs_folder}': {e}", fg=typer.colors.RED)
                 raise typer.Exit(code=1)
         else:
-            typer.echo(f"Usando pasta base existente: {abs_folder}")
+            typer.echo(f"Using existing base folder: {abs_folder}")
 
     abs_download_base_folder = os.path.abspath(download_base_folder)
     abs_processed_base_folder = os.path.abspath(processed_base_folder)
     abs_epub_base_folder = os.path.abspath(epub_base_folder)
 
-    # Variáveis para armazenar metadados e caminhos
+    # Variables to store metadata and paths
     first_chapter_to_crawl = story_url
     final_story_title = story_title_param
     final_author_name = author_name_param
-    story_slug_for_folders = None # Será usado para criar subpastas consistentes
+    story_slug_for_folders = None # Will be used to create consistent subfolders
 
     # --- 0. Fetch metadata if overview URL ---
     if is_overview_url(story_url):
-        typer.echo(f"\n--- Etapa 0: Buscando metadados de {story_url} ---")
+        typer.echo(f"\n--- Step 0: Fetching metadata from {story_url} ---")
         metadata = fetch_story_metadata_and_first_chapter(story_url)
         if not metadata or not metadata.get('first_chapter_url'):
-            typer.secho("Falha ao obter metadados ou URL do primeiro capítulo. Abortando.", fg=typer.colors.RED)
+            typer.secho("Failed to get metadata or first chapter URL. Aborting.", fg=typer.colors.RED)
             raise typer.Exit(code=1)
 
         first_chapter_to_crawl = metadata['first_chapter_url']
         story_slug_for_folders = metadata.get('story_slug', None)
 
-        if not final_story_title and metadata.get('story_title') != "Título Desconhecido":
+        if not final_story_title and metadata.get('story_title') != "Unknown Title":
             final_story_title = metadata['story_title']
-            typer.echo(f"Título da história (da overview): {final_story_title}")
-        if not final_author_name and metadata.get('author_name') != "Autor Desconhecido":
+            typer.echo(f"Story title (from overview): {final_story_title}")
+        if not final_author_name and metadata.get('author_name') != "Unknown Author":
             final_author_name = metadata['author_name']
-            typer.echo(f"Autor (da overview): {final_author_name}")
+            typer.echo(f"Author (from overview): {final_author_name}")
 
-        typer.echo(f"URL do primeiro capítulo para download: {first_chapter_to_crawl}")
+        typer.echo(f"First chapter URL for download: {first_chapter_to_crawl}")
         if story_slug_for_folders:
-             typer.echo(f"Slug da história para pastas: {story_slug_for_folders}")
+             typer.echo(f"Story slug for folders: {story_slug_for_folders}")
 
-    else: # É uma URL de capítulo direto
-        typer.echo("URL fornecida é de um capítulo direto.")
-        # Tenta extrair o slug da URL do capítulo para nome da pasta
+    else: # It's a direct chapter URL
+        typer.echo("Provided URL is a direct chapter URL.")
+        # Tries to extract the slug from the chapter URL for the folder name
         try:
             slug_parts = first_chapter_to_crawl.split('/fiction/')[1].split('/')
             if len(slug_parts) > 1:
                 story_slug_for_folders = re.sub(r'[\\/*?:"<>|]', "", slug_parts[1])
                 story_slug_for_folders = re.sub(r'\s+', '_', story_slug_for_folders)[:100]
-                typer.echo(f"Slug inferido da URL do capítulo para pastas: {story_slug_for_folders}")
+                typer.echo(f"Inferred slug from chapter URL for folders: {story_slug_for_folders}")
         except IndexError:
-            typer.echo("Não foi possível inferir o slug da URL do capítulo para nome de pasta.")
+            typer.echo("Could not infer slug from chapter URL for folder name.")
 
 
-    # Se o slug ainda não foi definido (ex: URL de capítulo inválida ou overview falhou em extrair)
-    # ou se o título/autor não foram definidos e não foram fornecidos.
+    # If the slug has not yet been defined (e.g., invalid chapter URL or overview failed to extract)
+    # or if the title/author were not defined and were not provided.
     if not story_slug_for_folders:
-        # Gera um slug baseado no título se disponível, ou um slug genérico
+        # Generates a slug based on the title if available, or a generic slug
         if final_story_title and final_story_title != "Archived Royal Road Story":
             story_slug_for_folders = re.sub(r'[\\/*?:"<>|]', "", final_story_title)
             story_slug_for_folders = re.sub(r'\s+', '_', story_slug_for_folders).lower()[:50]
-            typer.echo(f"Slug para pastas gerado a partir do título: {story_slug_for_folders}")
+            typer.echo(f"Slug for folders generated from title: {story_slug_for_folders}")
         else:
-            story_slug_for_folders = f"story_{int(time.time())}" # Fallback muito genérico
-            typer.echo(f"AVISO: Usando slug genérico para pastas: {story_slug_for_folders}")
+            story_slug_for_folders = f"story_{int(time.time())}" # Very generic fallback
+            typer.echo(f"WARNING: Using generic slug for folders: {story_slug_for_folders}")
 
 
-    # Define padrões se ainda não foram preenchidos pelos metadados ou parâmetros
+    # Defines defaults if not yet filled by metadata or parameters
     if not final_story_title:
-        # Se o slug foi bem definido e o título não, tenta usar o slug como base para o título
+        # If the slug was well defined and the title was not, try to use the slug as a basis for the title
         if story_slug_for_folders and not story_slug_for_folders.startswith("story_"):
              final_story_title = story_slug_for_folders.replace('-', ' ').replace('_', ' ').title()
-             typer.echo(f"Título do EPUB (inferido do slug): {final_story_title}")
+             typer.echo(f"EPUB title (inferred from slug): {final_story_title}")
         else:
-            final_story_title = "Archived Royal Road Story" # Padrão do Typer
-            typer.echo(f"Título do EPUB (padrão): {final_story_title}")
+            final_story_title = "Archived Royal Road Story" # Typer default
+            typer.echo(f"EPUB title (default): {final_story_title}")
 
     if not final_author_name:
-        final_author_name = "Royal Road Archiver" # Padrão do Typer
-        typer.echo(f"Autor do EPUB (padrão): {final_author_name}")
+        final_author_name = "Royal Road Archiver" # Typer default
+        typer.echo(f"EPUB author (default): {final_author_name}")
 
 
     # --- 1. Download Step ---
-    typer.echo(f"\n--- Etapa 1: Baixando capítulos de {first_chapter_to_crawl} ---")
-    typer.echo(f"Capítulos HTML brutos serão salvos em uma subpasta sob: {abs_download_base_folder}")
+    typer.echo(f"\n--- Step 1: Downloading chapters from {first_chapter_to_crawl} ---")
+    typer.echo(f"Raw HTML chapters will be saved in a subfolder under: {abs_download_base_folder}")
 
     story_specific_download_folder = None
     try:
-        # download_story criará a subpasta {story_slug_for_folders} dentro de abs_download_base_folder
+        # download_story will create the subfolder {story_slug_for_folders} inside abs_download_base_folder
         story_specific_download_folder = download_story(first_chapter_to_crawl, abs_download_base_folder, story_slug_override=story_slug_for_folders)
         if not story_specific_download_folder or not os.path.isdir(story_specific_download_folder):
-            typer.secho("Erro: A pasta de download da história não foi criada ou retornada corretamente.", fg=typer.colors.RED)
+            typer.secho("Error: The story download folder was not created or returned correctly.", fg=typer.colors.RED)
             raise typer.Exit(code=1)
-        typer.secho(f"Download bem-sucedido. Conteúdo salvo em: {story_specific_download_folder}", fg=typer.colors.GREEN)
+        typer.secho(f"Download successful. Content saved in: {story_specific_download_folder}", fg=typer.colors.GREEN)
 
     except Exception as e:
-        typer.secho(f"\nOcorreu um erro durante a etapa de download: {e}", fg=typer.colors.RED)
+        typer.secho(f"\nAn error occurred during the download step: {e}", fg=typer.colors.RED)
         typer.echo(traceback.format_exc())
         raise typer.Exit(code=1)
 
 
     # --- 2. Process Step ---
-    typer.echo(f"\n--- Etapa 2: Processando capítulos da história de {story_specific_download_folder} ---")
-    # A pasta processada será abs_processed_base_folder/story_slug_for_folders
+    typer.echo(f"\n--- Step 2: Processing story chapters from {story_specific_download_folder} ---")
+    # The processed folder will be abs_processed_base_folder/story_slug_for_folders
     story_specific_processed_folder = os.path.join(abs_processed_base_folder, story_slug_for_folders)
-    typer.echo(f"Capítulos processados serão salvos em: {story_specific_processed_folder}")
+    typer.echo(f"Processed chapters will be saved in: {story_specific_processed_folder}")
 
     try:
-        # process_story_chapters recebe a pasta de input (download) e a pasta de output específica para a história processada
+        # process_story_chapters receives the input folder (download) and the specific output folder for the processed story
         process_story_chapters(story_specific_download_folder, story_specific_processed_folder)
         if not os.path.isdir(story_specific_processed_folder):
-             typer.secho(f"Erro: Pasta da história processada '{story_specific_processed_folder}' não foi criada como esperado.", fg=typer.colors.RED)
+             typer.secho(f"Error: Processed story folder '{story_specific_processed_folder}' was not created as expected.", fg=typer.colors.RED)
              raise typer.Exit(code=1)
-        typer.secho(f"Processamento bem-sucedido. Conteúdo limpo salvo em: {story_specific_processed_folder}", fg=typer.colors.GREEN)
+        typer.secho(f"Processing successful. Cleaned content saved in: {story_specific_processed_folder}", fg=typer.colors.GREEN)
     except Exception as e:
-        typer.secho(f"\nOcorreu um erro durante a etapa de processamento: {e}", fg=typer.colors.RED)
+        typer.secho(f"\nAn error occurred during the processing step: {e}", fg=typer.colors.RED)
         typer.echo(traceback.format_exc())
         raise typer.Exit(code=1)
 
     # --- 3. Build EPUB Step ---
-    typer.echo(f"\n--- Etapa 3: Construindo EPUB(s) de {story_specific_processed_folder} ---")
-    typer.echo(f"Arquivos EPUB serão salvos em: {abs_epub_base_folder}")
+    typer.echo(f"\n--- Step 3: Building EPUB(s) from {story_specific_processed_folder} ---")
+    typer.echo(f"EPUB files will be saved in: {abs_epub_base_folder}")
 
     effective_chapters_per_epub = chapters_per_epub if chapters_per_epub > 0 else 999999
 
     try:
         success = build_epubs_for_story(
-            input_folder=story_specific_processed_folder, # Pasta específica com HTMLs limpos
-            output_folder=abs_epub_base_folder,       # Pasta base para salvar os .epub
+            input_folder=story_specific_processed_folder, # Specific folder with cleaned HTMLs
+            output_folder=abs_epub_base_folder,       # Base folder to save the .epub files
             chapters_per_epub=effective_chapters_per_epub,
             author_name=final_author_name,
             story_title=final_story_title
         )
         if success:
-            typer.secho(f"\nGeração de EPUB bem-sucedida. Arquivos salvos em: {abs_epub_base_folder}", fg=typer.colors.GREEN)
+            typer.secho(f"\nEPUB generation successful. Files saved in: {abs_epub_base_folder}", fg=typer.colors.GREEN)
         else:
-            typer.secho(f"\nGeração de EPUB foi pulada ou falhou. Verifique os logs acima.", fg=typer.colors.YELLOW)
+            typer.secho(f"\nEPUB generation was skipped or failed. Check logs above.", fg=typer.colors.YELLOW)
     except Exception as e:
-        typer.secho(f"\nOcorreu um erro durante a etapa de construção do EPUB: {e}", fg=typer.colors.RED)
+        typer.secho(f"\nAn error occurred during the EPUB building step: {e}", fg=typer.colors.RED)
         typer.echo(traceback.format_exc())
         raise typer.Exit(code=1)
 
-    typer.secho("\n--- Processo completo concluído com sucesso! ---", fg=typer.colors.CYAN)
+    typer.secho("\n--- Full process completed successfully! ---", fg=typer.colors.CYAN)
 
 
 if __name__ == "__main__":
-    # Adicionar para permitir import random no crawler.py se ele estiver lá
+    # Add to allow import random in crawler.py if it's there
     import random
     app()


### PR DESCRIPTION
This commit translates all user-facing strings, comments, and internal messages from Portuguese to English across the following files:
- main.py
- core/crawler.py
- core/epub_builder.py
- core/processor.py

Key changes include:
- Updating help messages, prompts, and error outputs.
- Translating default values and fallback text.
- Changing language metadata in generated EPUBs from 'pt-BR' to 'en'.
- Changing the lang attribute in generated HTML files (chapters and processed files) to 'en'.
- Ensuring consistency in naming conventions (e.g., "chapter" instead of "capitulo").
- An existing import for `time` was missing in `main.py` and has been added.