### PR TITLE
Fix: Correct markdown formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ It's highly recommended to use a virtual environment to manage project dependenc
             .\.venv\Scripts\activate
             ```
         -   **On macOS and Linux:**
-            `bash
-
-    source .venv/bin/activate
-    `        Your terminal prompt should change to indicate that the virtual environment is active (e.g.,`(.venv) your-prompt$`).
+            ```bash
+            source .venv/bin/activate
+            ```
+            Your terminal prompt should change to indicate that the virtual environment is active (e.g.,`(.venv) your-prompt$`).
 
 4.  **Install dependencies:**
 


### PR DESCRIPTION
The `bash` keyword for the macOS and Linux command was on a new line, causing the markdown to not render correctly. This commit moves the `bash` keyword to the same line as the triple backticks to fix the rendering issue.