### PR TITLE
feat: Implement automatic cleanup of intermediate files for full-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,12 @@ python main.py <command> --help
 
 -   **`full-process`**: Performs the entire sequence: download, process, and build EPUB.
     ```bash
-    python main.py full-process <STORY_URL_OR_CHAPTER_URL> --start-chapter-url <SPECIFIC_CHAPTER_URL_TO_START_FROM> -c <CHAPTERS_PER_EPUB> --author "<AUTHOR_NAME>" --title "<STORY_TITLE>"
+    python main.py full-process <STORY_URL_OR_CHAPTER_URL> --start-chapter-url <SPECIFIC_CHAPTER_URL_TO_START_FROM> -c <CHAPTERS_PER_EPUB> --author "<AUTHOR_NAME>" --title "<STORY_TITLE>" --keep-intermediate-files
     ```
     -   This command combines the functionality of `crawl`, `process`, and `build-epub`.
     -   It uses default base folders: `downloaded_stories`, `processed_stories`, and `epubs`.
+    -   **Cleanup**: By default, after successfully generating the EPUB(s), the intermediate folders (`downloaded_stories/story-slug` and `processed_stories/story-slug`) are automatically deleted to save space.
+    -   `--keep-intermediate-files`: (Optional) Add this flag if you want to preserve the downloaded (raw HTML) and processed (cleaned HTML) chapter folders. This can be useful for debugging or if you want to re-process or re-build EPUBs with different settings without re-downloading.
 
 ### Examples:
 


### PR DESCRIPTION
This change modifies the 'full-process' command to automatically delete the intermediate directories created during the download and processing steps (i.e., 'downloaded_stories/<story_slug>' and 'processed_stories/<story_slug>') after the EPUB generation is complete.

This behavior is enabled by default to save disk space. A new command-line option, '--keep-intermediate-files', has been added. When this flag is present, the cleanup step will be skipped, allowing you to retain these intermediate files for debugging or other purposes.

The README.md has also been updated to reflect this new functionality and document the '--keep-intermediate-files' option.