### PR TITLE
Refactor: Improve modularity and separation of concerns

### DIFF
--- a/core/cli_helpers.py
+++ b/core/cli_helpers.py
@@ -31,61 +31,133 @@ def _infer_slug_from_url(url: str) -> Optional[str]:
     return None
 
 def resolve_crawl_url_and_metadata(
+def resolve_crawl_url_and_metadata_logic(
     story_url_arg: str,
     start_chapter_url_param: Optional[str]
-) -> Tuple[Optional[str], Optional[Dict], Optional[str]]:
+) -> Dict:
     """
     Determines the actual URL to start crawling from and fetches metadata if applicable.
-
-    Returns:
-        A tuple containing:
-        - actual_crawl_start_url (str | None): The URL to start crawling from.
-        - fetched_metadata (dict | None): Fetched metadata if story_url_arg was an overview.
-        - initial_slug (str | None): An initial slug derived from metadata or URL.
+    This is the logic-only version.
     """
+    logs = []
     fetched_metadata: Optional[Dict] = None
     actual_crawl_start_url: Optional[str] = None
     initial_slug: Optional[str] = None
 
     if is_overview_url(story_url_arg):
-        typer.echo(f"Story URL '{story_url_arg}' detected as overview. Fetching metadata...")
+        logs.append({'level': 'info', 'message': f"Story URL '{story_url_arg}' detected as overview. Fetching metadata..."})
         metadata_result = fetch_story_metadata_and_first_chapter(story_url_arg)
         if not metadata_result:
-            typer.secho(f"Warning: Failed to fetch metadata from {story_url_arg}. Proceeding with potentially limited info.", fg=typer.colors.YELLOW)
+            logs.append({'level': 'warning', 'message': f"Warning: Failed to fetch metadata from {story_url_arg}. Proceeding with potentially limited info."})
         else:
             fetched_metadata = metadata_result
             initial_slug = fetched_metadata.get('story_slug')
-            typer.echo(f"Metadata fetched. Initial slug: '{initial_slug}', First chapter from meta: '{fetched_metadata.get('first_chapter_url')}'")
+            logs.append({'level': 'info', 'message': f"Metadata fetched. Initial slug: '{initial_slug}', First chapter from meta: '{fetched_metadata.get('first_chapter_url')}'"})
 
         if start_chapter_url_param:
             actual_crawl_start_url = start_chapter_url_param
-            typer.echo(f"Using user-specified start chapter URL: {actual_crawl_start_url}")
+            logs.append({'level': 'info', 'message': f"Using user-specified start chapter URL: {actual_crawl_start_url}"})
         elif fetched_metadata and fetched_metadata.get('first_chapter_url'):
             actual_crawl_start_url = fetched_metadata['first_chapter_url']
-            typer.echo(f"Using first chapter URL from metadata: {actual_crawl_start_url}")
+            logs.append({'level': 'info', 'message': f"Using first chapter URL from metadata: {actual_crawl_start_url}"})
         else:
-            typer.secho(f"Error: Overview URL provided but could not determine first chapter URL and no --start-chapter-url given.", fg=typer.colors.RED)
-            return None, fetched_metadata, initial_slug # Error case
+            logs.append({'level': 'error', 'message': f"Error: Overview URL provided but could not determine first chapter URL and no --start-chapter-url given."})
+            return {
+                'actual_crawl_start_url': None,
+                'fetched_metadata': fetched_metadata,
+                'initial_slug': initial_slug,
+                'logs': logs
+            } # Error case
 
     else: # story_url_arg is a chapter URL
-        typer.echo(f"Story URL '{story_url_arg}' detected as a chapter page.")
+        logs.append({'level': 'info', 'message': f"Story URL '{story_url_arg}' detected as a chapter page."})
         if start_chapter_url_param:
             actual_crawl_start_url = start_chapter_url_param
-            typer.echo(f"Using user-specified start chapter URL: {actual_crawl_start_url}")
+            logs.append({'level': 'info', 'message': f"Using user-specified start chapter URL: {actual_crawl_start_url}"})
         else:
             actual_crawl_start_url = story_url_arg
-            typer.echo(f"Using provided chapter URL as start point: {actual_crawl_start_url}")
+            logs.append({'level': 'info', 'message': f"Using provided chapter URL as start point: {actual_crawl_start_url}"})
         
-        # Try to infer slug from the chapter URL if no metadata pass was made
-        if not initial_slug: # Should be true here
+        if not initial_slug: 
             initial_slug = _infer_slug_from_url(story_url_arg)
-            typer.echo(f"Inferred initial slug from chapter URL '{story_url_arg}': '{initial_slug}'")
-
+            logs.append({'level': 'info', 'message': f"Inferred initial slug from chapter URL '{story_url_arg}': '{initial_slug}'"})
 
     if actual_crawl_start_url and "/chapter/" not in actual_crawl_start_url:
-        typer.secho(f"Warning: Resolved crawl URL '{actual_crawl_start_url}' does not appear to be a valid chapter URL.", fg=typer.colors.YELLOW)
+        logs.append({'level': 'warning', 'message': f"Warning: Resolved crawl URL '{actual_crawl_start_url}' does not appear to be a valid chapter URL."})
 
-    return actual_crawl_start_url, fetched_metadata, initial_slug
+    return {
+        'actual_crawl_start_url': actual_crawl_start_url,
+        'fetched_metadata': fetched_metadata,
+        'initial_slug': initial_slug,
+        'logs': logs
+    }
+
+def resolve_crawl_url_and_metadata(
+    story_url_arg: str,
+    start_chapter_url_param: Optional[str]
+) -> Tuple[Optional[str], Optional[Dict], Optional[str]]:
+    """
+    Determines the actual URL to start crawling from and fetches metadata if applicable.
+    This function now calls the _logic version and handles CLI output.
+    """
+    result = resolve_crawl_url_and_metadata_logic(story_url_arg, start_chapter_url_param)
+
+    for log_entry in result['logs']:
+        if log_entry['level'] == 'info':
+            typer.echo(log_entry['message'])
+        elif log_entry['level'] == 'warning':
+            typer.secho(log_entry['message'], fg=typer.colors.YELLOW)
+        elif log_entry['level'] == 'error':
+            typer.secho(log_entry['message'], fg=typer.colors.RED)
+
+    return result['actual_crawl_start_url'], result['fetched_metadata'], result['initial_slug']
+
+def determine_story_slug_for_folders(
+    story_url_arg: str,
+    start_chapter_url_param: Optional[str],
+    fetched_metadata: Optional[Dict],
+    initial_slug_from_resolve: Optional[str],
+    title_param: Optional[str]
+) -> Dict:
+    """Determines the definitive story slug for use in folder naming. Logic-only version."""
+    logs = []
+    story_slug: Optional[str] = None
+
+    if fetched_metadata and fetched_metadata.get('story_slug'):
+        story_slug = fetched_metadata['story_slug']
+        logs.append({'level': 'info', 'message': f"Using slug from fetched metadata: '{story_slug}'"})
+    elif initial_slug_from_resolve:
+        story_slug = initial_slug_from_resolve
+        logs.append({'level': 'info', 'message': f"Using initial slug from URL resolve step: '{story_slug}'"})
+    
+    if not story_slug: 
+        story_slug = _infer_slug_from_url(story_url_arg) 
+        if story_slug:
+            logs.append({'level': 'info', 'message': f"Inferred slug from story_url_arg '{story_url_arg}': '{story_slug}'"})
+
+    if not story_slug and start_chapter_url_param:
+        story_slug = _infer_slug_from_url(start_chapter_url_param) 
+        if story_slug:
+            logs.append({'level': 'info', 'message': f"Inferred slug from start_chapter_url_param '{start_chapter_url_param}': '{story_slug}'"})
+
+    if not story_slug:
+        if title_param and title_param not in ["Archived Royal Road Story", "Unknown Story"]:
+            slug_from_title = re.sub(r'[^\w\s-]', '', title_param).strip()
+            slug_from_title = re.sub(r'\s+', '_', slug_from_title).lower()
+            story_slug = slug_from_title[:50] 
+            logs.append({'level': 'info', 'message': f"Generated slug from title_param: '{story_slug}'"})
+        else:
+            story_slug = f"story_{int(time.time())}"
+            logs.append({'level': 'warning', 'message': f"Warning: Could not determine a descriptive slug. Using generic timed slug: '{story_slug}'"})
+    
+    if story_slug: # Ensure story_slug is not None before sanitizing
+        story_slug = re.sub(r'[\\/*?:"<>|]', "", story_slug)
+        story_slug = re.sub(r'\s+', '_', story_slug).lower()
+    
+    final_slug = story_slug if story_slug else f"story_{int(time.time())}" 
+    logs.append({'level': 'info', 'message': f"Final story slug for folders: '{final_slug}'"})
+    
+    return {'story_slug': final_slug, 'logs': logs}
 
 def determine_story_slug_for_folders(
     story_url_arg: str,
@@ -95,42 +167,22 @@ def determine_story_slug_for_folders(
     title_param: Optional[str]
 ) -> str:
     """Determines the definitive story slug for use in folder naming."""
-    story_slug: Optional[str] = None
+    result = determine_story_slug_for_folders_logic(
+        story_url_arg,
+        start_chapter_url_param,
+        fetched_metadata,
+        initial_slug_from_resolve,
+        title_param
+    )
 
-    if fetched_metadata and fetched_metadata.get('story_slug'):
-        story_slug = fetched_metadata['story_slug']
-        typer.echo(f"Using slug from fetched metadata: '{story_slug}'")
-    elif initial_slug_from_resolve:
-        story_slug = initial_slug_from_resolve
-        typer.echo(f"Using initial slug from URL resolve step: '{story_slug}'")
-    
-    if not story_slug: # If metadata didn't provide it or resolve didn't find it
-        story_slug = _infer_slug_from_url(story_url_arg) # Try main story URL
-        if story_slug:
-             typer.echo(f"Inferred slug from story_url_arg '{story_url_arg}': '{story_slug}'")
+    for log_entry in result['logs']:
+        if log_entry['level'] == 'info':
+            typer.echo(log_entry['message'])
+        elif log_entry['level'] == 'warning':
+            typer.secho(log_entry['message'], fg=typer.colors.YELLOW)
+        # No error level defined for this function's logs in the original code
 
-    if not story_slug and start_chapter_url_param:
-        story_slug = _infer_slug_from_url(start_chapter_url_param) # Then try from start_chapter_url
-        if story_slug:
-            typer.echo(f"Inferred slug from start_chapter_url_param '{start_chapter_url_param}': '{story_slug}'")
-
-    if not story_slug:
-        if title_param and title_param not in ["Archived Royal Road Story", "Unknown Story"]:
-            # Sanitize title to create a slug
-            slug_from_title = re.sub(r'[^\w\s-]', '', title_param).strip()
-            slug_from_title = re.sub(r'\s+', '_', slug_from_title).lower()
-            story_slug = slug_from_title[:50] # Limit length
-            typer.echo(f"Generated slug from title_param: '{story_slug}'")
-        else:
-            story_slug = f"story_{int(time.time())}"
-            typer.secho(f"Warning: Could not determine a descriptive slug. Using generic timed slug: '{story_slug}'", fg=typer.colors.YELLOW)
-    
-    # Final sanitization (though _infer_slug_from_url already does some)
-    story_slug = re.sub(r'[\\/*?:"<>|]', "", story_slug)
-    story_slug = re.sub(r'\s+', '_', story_slug).lower()
-    
-    typer.echo(f"Final story slug for folders: '{story_slug}'")
-    return story_slug if story_slug else f"story_{int(time.time())}" # Ensure it's never empty
+    return result['story_slug']
 
 def finalize_epub_metadata(
     title_param: Optional[str],
@@ -141,8 +193,9 @@ def finalize_epub_metadata(
     publisher_param: Optional[str],
     fetched_metadata: Optional[Dict],
     story_slug: str
-) -> Tuple[str, str, Optional[str], Optional[str], list, Optional[str]]:
-    """Finalizes metadata for EPUB creation."""
+) -> Dict:
+    """Finalizes metadata for EPUB creation. Logic-only version."""
+    logs = []
     final_story_title = "Archived Royal Road Story" # Default
     final_author_name = "Royal Road Archiver"   # Default
     final_cover_image_url: Optional[str] = None
@@ -186,5 +239,53 @@ def finalize_epub_metadata(
     elif fetched_metadata and fetched_metadata.get('publisher'):
         final_publisher = fetched_metadata['publisher']
 
-    typer.echo(f"EPUB Metadata: Title='{final_story_title}', Author='{final_author_name}', Cover='{final_cover_image_url}', Publisher='{final_publisher}', Tags='{final_tags}', Description Length='{len(final_description) if final_description else 0}'")
-    return final_story_title, final_author_name, final_cover_image_url, final_description, final_tags, final_publisher
+    logs.append({'level': 'info', 'message': f"EPUB Metadata: Title='{final_story_title}', Author='{final_author_name}', Cover='{final_cover_image_url}', Publisher='{final_publisher}', Tags='{final_tags}', Description Length='{len(final_description) if final_description else 0}'"})
+    
+    return {
+        'final_story_title': final_story_title,
+        'final_author_name': final_author_name,
+        'final_cover_image_url': final_cover_image_url,
+        'final_description': final_description,
+        'final_tags': final_tags,
+        'final_publisher': final_publisher,
+        'logs': logs
+    }
+
+def finalize_epub_metadata(
+    title_param: Optional[str],
+    author_param: Optional[str],
+    cover_url_param: Optional[str],
+    description_param: Optional[str],
+    tags_param: Optional[str], # Comma-separated string from Typer
+    publisher_param: Optional[str],
+    fetched_metadata: Optional[Dict],
+    story_slug: str
+) -> Tuple[str, str, Optional[str], Optional[str], list, Optional[str]]:
+    """Finalizes metadata for EPUB creation."""
+    result = finalize_epub_metadata_logic(
+        title_param,
+        author_param,
+        cover_url_param,
+        description_param,
+        tags_param,
+        publisher_param,
+        fetched_metadata,
+        story_slug
+    )
+
+    for log_entry in result['logs']:
+        # Assuming all logs from this function are info level as per original
+        if log_entry['level'] == 'info':
+            typer.echo(log_entry['message'])
+        # Add other levels here if they were used in the original, e.g.
+        # elif log_entry['level'] == 'warning':
+        #     typer.secho(log_entry['message'], fg=typer.colors.YELLOW)
+
+    return (
+        result['final_story_title'],
+        result['final_author_name'],
+        result['final_cover_image_url'],
+        result['final_description'],
+        result['final_tags'],
+        result['final_publisher']
+    )

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -134,3 +134,230 @@ class TestFinalizeEpubMetadata(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+from unittest.mock import patch, MagicMock # Added MagicMock
+import time # For determine_story_slug_for_folders_logic fallback slug
+
+# Import the _logic functions
+from core.cli_helpers import (
+    resolve_crawl_url_and_metadata_logic,
+    determine_story_slug_for_folders_logic,
+    finalize_epub_metadata_logic,
+    _infer_slug_from_url # if needed for some assertions, though it's private
+)
+
+class TestCliHelpersLogic(unittest.TestCase):
+
+    @patch('core.cli_helpers.fetch_story_metadata_and_first_chapter')
+    def test_resolve_overview_url_success(self, mock_fetch_metadata):
+        mock_fetch_metadata.return_value = {
+            'story_slug': 'test-slug',
+            'first_chapter_url': 'http://example.com/fiction/123/test-slug/chapter/456/chapter-one',
+            'story_title': 'Test Story',
+            'author_name': 'Test Author'
+        }
+        story_url = "http://example.com/fiction/123/test-slug"
+        result = resolve_crawl_url_and_metadata_logic(story_url, None)
+
+        self.assertEqual(result['actual_crawl_start_url'], 'http://example.com/fiction/123/test-slug/chapter/456/chapter-one')
+        self.assertIsNotNone(result['fetched_metadata'])
+        self.assertEqual(result['initial_slug'], 'test-slug')
+        self.assertTrue(any("Metadata fetched. Initial slug: 'test-slug'" in log['message'] for log in result['logs']))
+        self.assertTrue(any(f"Story URL '{story_url}' detected as overview" in log['message'] for log in result['logs']))
+
+    @patch('core.cli_helpers.fetch_story_metadata_and_first_chapter')
+    def test_resolve_overview_url_with_start_chapter_param(self, mock_fetch_metadata):
+        mock_fetch_metadata.return_value = {
+            'story_slug': 'test-slug',
+            'first_chapter_url': 'http://example.com/fiction/123/test-slug/chapter/456/chapter-one',
+        }
+        story_url = "http://example.com/fiction/123/test-slug"
+        user_start_chapter = "http://example.com/fiction/123/test-slug/chapter/789/custom-start"
+        result = resolve_crawl_url_and_metadata_logic(story_url, user_start_chapter)
+
+        self.assertEqual(result['actual_crawl_start_url'], user_start_chapter)
+        self.assertEqual(result['initial_slug'], 'test-slug')
+        self.assertTrue(any(f"Using user-specified start chapter URL: {user_start_chapter}" in log['message'] for log in result['logs']))
+
+    @patch('core.cli_helpers.fetch_story_metadata_and_first_chapter')
+    def test_resolve_overview_url_metadata_fetch_fails(self, mock_fetch_metadata):
+        mock_fetch_metadata.return_value = None # Simulate failure
+        story_url = "http://example.com/fiction/123/test-slug-fail"
+        result = resolve_crawl_url_and_metadata_logic(story_url, None)
+
+        # Even if metadata fails, if it's an overview and no start_chapter_url_param, it's an error state for URL determination
+        self.assertIsNone(result['actual_crawl_start_url'])
+        self.assertIsNone(result['fetched_metadata'])
+        self.assertIsNone(result['initial_slug'])
+        self.assertTrue(any(f"Warning: Failed to fetch metadata from {story_url}" in log['message'] for log in result['logs']))
+        self.assertTrue(any("Error: Overview URL provided but could not determine first chapter URL" in log['message'] for log in result['logs']))
+
+    @patch('core.cli_helpers.fetch_story_metadata_and_first_chapter')
+    def test_resolve_overview_url_metadata_fetch_fails_with_start_param(self, mock_fetch_metadata):
+        mock_fetch_metadata.return_value = None # Simulate failure
+        story_url = "http://example.com/fiction/123/test-slug-fail"
+        user_start_chapter = "http://example.com/custom/start/chapter"
+        result = resolve_crawl_url_and_metadata_logic(story_url, user_start_chapter)
+
+        self.assertEqual(result['actual_crawl_start_url'], user_start_chapter)
+        self.assertIsNone(result['fetched_metadata']) # Still None as fetch failed
+        self.assertIsNone(result['initial_slug']) # No metadata to get slug from
+        self.assertTrue(any(f"Warning: Failed to fetch metadata from {story_url}" in log['message'] for log in result['logs']))
+        self.assertTrue(any(f"Using user-specified start chapter URL: {user_start_chapter}" in log['message'] for log in result['logs']))
+
+
+    def test_resolve_chapter_url_no_param(self):
+        story_url = "http://example.com/fiction/123/a-story/chapter/456/the-chapter"
+        # No call to fetch_story_metadata_and_first_chapter should happen
+        result = resolve_crawl_url_and_metadata_logic(story_url, None)
+
+        self.assertEqual(result['actual_crawl_start_url'], story_url)
+        self.assertIsNone(result['fetched_metadata'])
+        self.assertEqual(result['initial_slug'], 'a-story') # Inferred from chapter URL
+        self.assertTrue(any(f"Story URL '{story_url}' detected as a chapter page." in log['message'] for log in result['logs']))
+        self.assertTrue(any(f"Using provided chapter URL as start point: {story_url}" in log['message'] for log in result['logs']))
+        self.assertTrue(any(f"Inferred initial slug from chapter URL '{story_url}': 'a-story'" in log['message'] for log in result['logs']))
+
+    def test_resolve_chapter_url_with_start_chapter_param(self):
+        story_url = "http://example.com/fiction/123/a-story/chapter/456/the-chapter"
+        user_start_chapter = "http://example.com/fiction/123/a-story/chapter/789/custom-start"
+        result = resolve_crawl_url_and_metadata_logic(story_url, user_start_chapter)
+
+        self.assertEqual(result['actual_crawl_start_url'], user_start_chapter)
+        self.assertIsNone(result['fetched_metadata'])
+        # initial_slug is inferred from the original story_url_arg, not the start_chapter_url_param in this path
+        self.assertEqual(result['initial_slug'], 'a-story')
+        self.assertTrue(any(f"Using user-specified start chapter URL: {user_start_chapter}" in log['message'] for log in result['logs']))
+
+    def test_resolve_url_warning_if_not_chapter_like(self):
+        story_url = "http://example.com/fiction/123/test-slug" # Overview, but let's say metadata gives non-chapter URL
+        
+        with patch('core.cli_helpers.fetch_story_metadata_and_first_chapter') as mock_fetch:
+            mock_fetch.return_value = {'first_chapter_url': 'http://example.com/not-a-chapter', 'story_slug': 'test-slug'}
+            result = resolve_crawl_url_and_metadata_logic(story_url, None)
+            self.assertEqual(result['actual_crawl_start_url'], 'http://example.com/not-a-chapter')
+            self.assertTrue(any("Warning: Resolved crawl URL 'http://example.com/not-a-chapter' does not appear to be a valid chapter URL." in log['message'] for log in result['logs']))
+
+        # Scenario: chapter URL is provided, but it's not chapter-like (less common)
+        chapter_like_url = "http://example.com/some/path/that/is/not/a/chapter"
+        result_chap = resolve_crawl_url_and_metadata_logic(chapter_like_url, None)
+        self.assertEqual(result_chap['actual_crawl_start_url'], chapter_like_url)
+        self.assertTrue(any(f"Warning: Resolved crawl URL '{chapter_like_url}' does not appear to be a valid chapter URL." in log['message'] for log in result_chap['logs']))
+
+    # --- Tests for determine_story_slug_for_folders_logic ---
+
+    def test_determine_slug_from_fetched_metadata(self):
+        fetched_metadata = {'story_slug': 'meta-slug'}
+        result = determine_story_slug_for_folders_logic("url", None, fetched_metadata, "init-slug", "title")
+        self.assertEqual(result['story_slug'], 'meta-slug')
+        self.assertTrue(any("Using slug from fetched metadata: 'meta-slug'" in log['message'] for log in result['logs']))
+
+    def test_determine_slug_from_initial_resolve(self):
+        result = determine_story_slug_for_folders_logic("url", None, None, "init-slug", "title")
+        self.assertEqual(result['story_slug'], 'init-slug')
+        self.assertTrue(any("Using initial slug from URL resolve step: 'init-slug'" in log['message'] for log in result['logs']))
+
+    def test_determine_slug_infer_from_story_url_arg(self):
+        story_url = "https://www.royalroad.com/fiction/12345/my-awesome-story/chapter/1/ch1"
+        # _infer_slug_from_url should extract "my-awesome-story"
+        result = determine_story_slug_for_folders_logic(story_url, None, None, None, "title")
+        self.assertEqual(result['story_slug'], 'my-awesome-story')
+        self.assertTrue(any("Inferred slug from story_url_arg" in log['message'] and "'my-awesome-story'" in log['message'] for log in result['logs']))
+
+    def test_determine_slug_infer_from_start_chapter_url_param(self):
+        start_url = "https://www.royalroad.com/fiction/54321/another-story-here/chapter/1/ch1"
+        # _infer_slug_from_url should extract "another-story-here"
+        result = determine_story_slug_for_folders_logic("main_url", start_url, None, None, "title")
+        self.assertEqual(result['story_slug'], 'another-story-here')
+        self.assertTrue(any("Inferred slug from start_chapter_url_param" in log['message'] and "'another-story-here'" in log['message'] for log in result['logs']))
+    
+    def test_determine_slug_generate_from_title_param(self):
+        title = "My Story Title With Spaces & Chars!"
+        # Expected: my_story_title_with_spaces_chars, limited to 50
+        expected_slug = "my_story_title_with_spaces_chars" 
+        result = determine_story_slug_for_folders_logic("url", None, None, None, title)
+        self.assertEqual(result['story_slug'], expected_slug)
+        self.assertTrue(any(f"Generated slug from title_param: '{expected_slug}'" in log['message'] for log in result['logs']))
+
+    def test_determine_slug_fallback_to_timed_slug(self):
+        with patch('time.time', return_value=1234567890): # Mock time
+            result = determine_story_slug_for_folders_logic(None, None, None, None, None) # All sources fail
+            expected_slug = "story_1234567890"
+            self.assertEqual(result['story_slug'], expected_slug)
+            self.assertTrue(any(f"Warning: Could not determine a descriptive slug. Using generic timed slug: '{expected_slug}'" in log['message'] for log in result['logs']))
+        
+        # Also test if title is default/generic
+        with patch('time.time', return_value=1234567891):
+            result_default_title = determine_story_slug_for_folders_logic(None, None, None, None, "Archived Royal Road Story")
+            expected_slug_2 = "story_1234567891"
+            self.assertEqual(result_default_title['story_slug'], expected_slug_2)
+            self.assertTrue(any(f"Warning: Could not determine a descriptive slug. Using generic timed slug: '{expected_slug_2}'" in log['message'] for log in result_default_title['logs']))
+
+
+    # --- Tests for finalize_epub_metadata_logic ---
+
+    def test_finalize_all_params_override_fetched(self):
+        params = {
+            'title_param': "CLI Title", 'author_param': "CLI Author", 'cover_url_param': "cli_cover.jpg",
+            'description_param': "CLI Description.", 'tags_param': "tag1,tag2", 'publisher_param': "CLI Publisher"
+        }
+        fetched_metadata = {
+            'story_title': "Fetched Title", 'author_name': "Fetched Author", 'cover_image_url': "fetched_cover.jpg",
+            'description': "Fetched Description.", 'tags': ['fetched_tag1'], 'publisher': "Fetched Publisher"
+        }
+        story_slug = "test-slug"
+        
+        result = finalize_epub_metadata_logic(**params, fetched_metadata=fetched_metadata, story_slug=story_slug)
+
+        self.assertEqual(result['final_story_title'], params['title_param'])
+        self.assertEqual(result['final_author_name'], params['author_param'])
+        self.assertEqual(result['final_cover_image_url'], params['cover_url_param'])
+        self.assertEqual(result['final_description'], params['description_param'])
+        self.assertEqual(result['final_tags'], ['tag1', 'tag2'])
+        self.assertEqual(result['final_publisher'], params['publisher_param'])
+        self.assertTrue(len(result['logs']) == 1) # Should have one summary log
+        self.assertTrue("EPUB Metadata: Title='CLI Title'" in result['logs'][0]['message'])
+
+    def test_finalize_fetched_metadata_used(self):
+        fetched_metadata = {
+            'story_title': "Fetched Story Title", 'author_name': "Fetched Story Author", 
+            'cover_image_url': "http://example.com/fetched_cover.png",
+            'description': "This is the fetched description.", 'tags': ["Fantasy", "Adventure"],
+            'publisher': "Fetched Publishing House"
+        }
+        story_slug = "another-slug"
+        
+        result = finalize_epub_metadata_logic(None, None, None, None, None, None, fetched_metadata, story_slug)
+
+        self.assertEqual(result['final_story_title'], fetched_metadata['story_title'])
+        self.assertEqual(result['final_author_name'], fetched_metadata['author_name'])
+        self.assertEqual(result['final_cover_image_url'], fetched_metadata['cover_image_url'])
+        self.assertEqual(result['final_description'], fetched_metadata['description'])
+        self.assertEqual(result['final_tags'], fetched_metadata['tags'])
+        self.assertEqual(result['final_publisher'], fetched_metadata['publisher'])
+        self.assertTrue("EPUB Metadata: Title='Fetched Story Title'" in result['logs'][0]['message'])
+
+    def test_finalize_defaults_and_slug_title_fallback(self):
+        # Case 1: Everything is None, title from good slug
+        result1 = finalize_epub_metadata_logic(None, None, None, None, None, None, None, "a-good-slug")
+        self.assertEqual(result1['final_story_title'], "A Good Slug")
+        self.assertEqual(result1['final_author_name'], "Royal Road Archiver") # Default
+        self.assertIsNone(result1['final_cover_image_url'])
+        self.assertEqual(result1['final_tags'], [])
+        self.assertTrue("EPUB Metadata: Title='A Good Slug'" in result1['logs'][0]['message'])
+
+        # Case 2: Slug is generic, title defaults
+        result2 = finalize_epub_metadata_logic(None, None, None, None, None, None, None, "story_123")
+        self.assertEqual(result2['final_story_title'], "Archived Royal Road Story") # Default
+        self.assertTrue("EPUB Metadata: Title='Archived Royal Road Story'" in result2['logs'][0]['message'])
+        
+    def test_finalize_tags_parsing(self):
+        result = finalize_epub_metadata_logic(None, None, None, None, "tag1, tag2 , tag3 ", None, None, "slug")
+        self.assertEqual(result['final_tags'], ["tag1", "tag2", "tag3"])
+
+        result_no_tags = finalize_epub_metadata_logic(None, None, None, None, None, None, None, "slug")
+        self.assertEqual(result_no_tags['final_tags'], [])
+
+        result_empty_tag_string = finalize_epub_metadata_logic(None, None, None, None, " , ", None, None, "slug")
+        self.assertEqual(result_empty_tag_string['final_tags'], [])


### PR DESCRIPTION
This commit introduces changes to improve the modularity of the application, primarily by separating core logic from CLI presentation and by restructuring parts of the main command flow. These changes aim to make it easier for multiple developers to work on the codebase with fewer conflicts and to enhance testability.

Key changes:

1.  **Refactored `core/cli_helpers.py`**:
    *   Logic-only functions (suffixed with `_logic`) were created for `resolve_crawl_url_and_metadata`, `determine_story_slug_for_folders`, and `finalize_epub_metadata`. These functions return data structures including detailed logs and do not contain any `typer` calls.
    *   The original functions in `cli_helpers.py` now call their `_logic` counterparts and handle the `typer` CLI output based on the returned logs.

2.  **Reviewed `main.py`**:
    *   Ensured `main.py` continues to function correctly with the refactored `cli_helpers.py` functions. The existing calls did not require modification due to the wrapper approach in `cli_helpers.py`.

3.  **Reviewed Core Modules (`crawler.py`, `processor.py`, `epub_builder.py`)**:
    *   Confirmed these modules remain free of `typer` dependencies, using standard `print` for logging, thus maintaining their CLI independence.

4.  **Updated `main.py`'s `full-process` Command**:
    *   The `full-process` command was internally restructured by breaking it down into several private helper functions (`_initialize_full_process`, `_run_download_step`, `_run_process_step`, `_run_build_epub_step`, `_run_cleanup_step`). This improves readability and maintainability of the command's workflow.

5.  **Added Unit Tests**:
    *   New unit tests were added to `tests/test_cli_helpers.py` (in a new class `TestCliHelpersLogic`) to specifically cover the new `_logic` functions in `core/cli_helpers.py`. These tests mock external dependencies and verify the correctness of the returned data and logs.