### PR TITLE
I've enabled default sentence removal in the full-process command.

### DIFF
--- a/core/default_sentences_to_remove.json
+++ b/core/default_sentences_to_remove.json
@@ -1,0 +1,3 @@
+[
+    "Stolen from its rightful author, this tale is not meant to be on Amazon; report any sightings."
+]

--- a/main.py
+++ b/main.py
@@ -260,10 +260,10 @@ def full_process_command(
         help="If True, preserves the downloaded and processed chapter folders. Defaults to False (deleting them)."
     ),
     sentence_removal_json_path: Optional[str] = typer.Option(
-        None,
+        "core/default_sentences_to_remove.json",
         "--remove-sentences-json",
         "-rsj",
-        help="Optional path to a JSON file with sentences to remove from the final EPUBs."
+        help="Optional path to a JSON file with sentences to remove from the final EPUBs. Defaults to core/default_sentences_to_remove.json containing a common boilerplate sentence."
     )
 ):
     """
@@ -335,6 +335,7 @@ def full_process_command(
         else:
             sentences_to_remove = None
             try:
+                log_info(f"Attempting to load sentences for removal from: {sentence_removal_json_path}")
                 with open(sentence_removal_json_path, 'r', encoding='utf-8') as f:
                     sentences_to_remove = json.load(f)
                 if not isinstance(sentences_to_remove, list) or not all(isinstance(s, str) for s in sentences_to_remove):


### PR DESCRIPTION
This change introduces a default sentence removal behavior.

Key changes:
- I added `core/default_sentences_to_remove.json` which contains a common boilerplate sentence ("Stolen from its rightful author, this tale is not meant to be on Amazon; report any sightings.").
- I modified `main.py` so that the `sentence_removal_json_path` option in the `full_process_command` now defaults to `core/default_sentences_to_remove.json`.
- The help message for this option has been updated to reflect the new default.
- I added a log message in `main.py` to indicate which sentence removal file is being loaded. This will help confirm the default is active when you don't provide an explicit path.

This makes the sentence removal active by default for the specified sentence, enhancing the out-of-the-box processing capabilities.