### PR TITLE
Fix: Add missing title tags to EPUB XHTML components

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,25 @@ python main.py <command> --help
         ]
         ```
 
+-   **`fix-epub-titles`**: Scans and fixes `<title>` tags in EPUBs.
+    ```bash
+    python main.py fix-epub-titles <FOLDER_PATH>
+    ```
+    -   `<FOLDER_PATH>`: Path to a folder containing EPUB files. The command searches recursively through subdirectories.
+    -   **Functionality**: For each `.epub` file found, this command inspects its internal XHTML components (like chapters, cover pages, etc.). It ensures that each XHTML file has a valid `<title>` tag within its `<head>` section.
+        -   For `cover.xhtml`, the title is set to "Cover".
+        -   For other XHTML files, it attempts to use the title from the EPUB's manifest for that item. If that's not suitable (e.g., "None", "Untitled"), it generates a title from the XHTML filename.
+    -   **Important**: This command directly modifies and overwrites the original EPUB files in place.
+    -   **Example Usages**:
+        -   To fix EPUBs within a specific story's output folder:
+            ```bash
+            python main.py fix-epub-titles epubs/my-story-slug/
+            ```
+        -   To fix all EPUBs located anywhere under the general `epubs/` directory:
+            ```bash
+            python main.py fix-epub-titles epubs/
+            ```
+
 ### Examples:
 
 1.  **Full process for a story from its overview page, using fetched metadata for EPUB:**

--- a/core/epub_builder.py
+++ b/core/epub_builder.py
@@ -429,7 +429,8 @@ def fix_xhtml_titles_in_epub(book: epub.EpubBook) -> bool:
         item_modified_this_iteration = False
         try:
             original_content = item.get_content().decode('utf-8', errors='ignore')
-            soup = BeautifulSoup(original_content, 'html.parser')
+            soup = BeautifulSoup(original_content, 'xml') # Changed parser to 'xml'
+            log_debug(f"  Parsing item '{item.get_name()}' using 'xml' parser (lxml required).")
 
             # Ensure <html> tag has the correct XHTML namespace
             html_tag = soup.find('html')

--- a/core/epub_builder.py
+++ b/core/epub_builder.py
@@ -418,7 +418,7 @@ def fix_xhtml_titles_in_epub(book: epub.EpubBook) -> bool:
         True if any modifications were made to the book's items, False otherwise.
     """
     overall_modified_status = False
-    log_debug(f"Starting fix_xhtml_titles_in_epub for book ID: {book.get_identifier()}")
+    log_debug(f"Starting fix_xhtml_titles_in_epub for book with main title (from OPF): {book.title}")
 
     for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT):
         if not (item.get_name().lower().endswith(('.xhtml', '.html'))):

--- a/core/epub_builder.py
+++ b/core/epub_builder.py
@@ -1,7 +1,8 @@
 # core/epub_builder.py
 import os
 import requests
-from ebooklib import epub
+import ebooklib # Added for ebooklib.ITEM_DOCUMENT
+from ebooklib import epub # For epub.EpubBook etc.
 from ebooklib.epub import read_epub, EpubHtml, EpubNav # Added EpubHtml, EpubNav here
 from bs4 import BeautifulSoup
 from typing import Optional, List # List is already here
@@ -54,7 +55,7 @@ def _load_chapter_content(file_path: str, chapter_title: str, chapter_uid: str) 
             title_tag = soup.new_tag('title')
             title_tag.string = chapter_title
             head.append(title_tag)
-
+        
         html_content = str(soup)
 
         # Create EpubHtml item
@@ -232,12 +233,12 @@ def build_epubs_for_story(
                 print(f"   Cover image '{image_filename}' added to EPUB.")
 
                 # Ensure cover.xhtml has the title "Cover"
-                for item in book.get_items_of_type(epub.ITEM_DOCUMENT):
+                for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT): # Changed to ebooklib.ITEM_DOCUMENT
                     if item.get_name() == 'cover.xhtml' or item.file_name == 'cover.xhtml': # Check both name and file_name for robustness
                         try:
                             cover_html_content = item.get_content().decode('utf-8')
                             cover_soup = BeautifulSoup(cover_html_content, 'html.parser')
-
+                            
                             head = cover_soup.find('head')
                             if not head:
                                 head = cover_soup.new_tag('head')
@@ -252,7 +253,7 @@ def build_epubs_for_story(
                             if not title_tag:
                                 title_tag = cover_soup.new_tag('title')
                                 head.append(title_tag)
-
+                            
                             title_tag.string = "Cover"
                             item.set_content(str(cover_soup).encode('utf-8'))
                             print(f"   Updated title for '{item.file_name}' to 'Cover'.")
@@ -417,7 +418,7 @@ def fix_xhtml_titles_in_epub(book: epub.EpubBook) -> bool:
     """
     overall_modified_status = False # Tracks if any item in the book was changed
 
-    for item in book.get_items_of_type(epub.ITEM_DOCUMENT):
+    for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT): # Changed to ebooklib.ITEM_DOCUMENT
         if not (item.get_name().lower().endswith(('.xhtml', '.html'))):
             continue
 
@@ -451,7 +452,7 @@ def fix_xhtml_titles_in_epub(book: epub.EpubBook) -> bool:
 
 
             title_tag = head.find('title')
-
+            
             desired_title_text = ""
             # Check if it's cover.xhtml based on typical naming by ebooklib or common use
             # ebooklib's set_cover often names the XHTML file 'cover.xhtml' and gives it id 'cover'
@@ -472,7 +473,7 @@ def fix_xhtml_titles_in_epub(book: epub.EpubBook) -> bool:
                     desired_title_text = ' '.join(word.capitalize() for word in processed_filename.split() if word)
                     if not desired_title_text: # Ultimate fallback
                         desired_title_text = "Untitled Document"
-
+            
             if not title_tag:
                 title_tag = soup.new_tag('title')
                 title_tag.string = desired_title_text

--- a/core/epub_builder.py
+++ b/core/epub_builder.py
@@ -506,12 +506,25 @@ def fix_xhtml_titles_in_epub(book: epub.EpubBook) -> bool:
 
             # Action: Create or update title tag
             if not title_tag:
-                title_tag = soup.new_tag('title')
-                title_tag.string = desired_title_text
-                head.append(title_tag)
+                log_debug(f"  No existing <title> tag found in <head> for {item.get_name()}. Creating and reconstructing <head>.")
+                new_title_tag = soup.new_tag('title') # Renamed to avoid confusion
+                new_title_tag.string = desired_title_text
+
+                original_head_children = list(head.children)
+                log_debug(f"  Original <head> had {len(original_head_children)} child(ren) before clearing for title insertion.")
+                head.clear() # Clear out existing children from head
+
+                head.append(new_title_tag) # Add the new title first
+
+                # Append original children back after the title
+                for child in original_head_children:
+                    head.append(child)
+
                 item_modified_this_iteration = True
-                log_debug(f"  CREATED new <title> tag with content: '{title_tag.string}' for {item.get_name()}")
+                # Use new_title_tag.string for the log message as title_tag might be None here
+                log_debug(f"  Reconstructed <head> for {item.get_name()}. New <title> is '{new_title_tag.string}'. Total <head> children: {len(head.contents)}.")
             elif title_tag.string != desired_title_text:
+                # This part for updating an existing title remains the same
                 title_tag.string = desired_title_text
                 item_modified_this_iteration = True
                 log_debug(f"  UPDATED existing <title> tag to: '{title_tag.string}' for {item.get_name()}")

--- a/main.py
+++ b/main.py
@@ -764,8 +764,8 @@ def fix_epub_titles_command(
     input_folder: str = typer.Argument(..., help="Path to the folder containing EPUB files to fix. It will search recursively in subdirectories.")
 ):
     """
-    Scans a folder (and its subdirectories) for EPUB files and fixes missing <title> 
-    tags in their internal XHTML components (chapters and cover). 
+    Scans a folder (and its subdirectories) for EPUB files and fixes missing <title>
+    tags in their internal XHTML components (chapters and cover).
     This command overwrites the original EPUB files.
     """
     log_info(f"Starting EPUB title fixing process for folder: {input_folder}")
@@ -793,7 +793,7 @@ def fix_epub_titles_command(
                         # Define epub.write_epub options; {} means use defaults
                         # epub3_pages=False and toc_depth=2 were used in build_epubs_for_story
                         # Using {} should be fine for just saving modifications.
-                        epub.write_epub(epub_file_path, book, {}) 
+                        epub.write_epub(epub_file_path, book, {})
                         log_success(f"Successfully fixed titles and saved: {epub_file_path}")
                         fixed_count += 1
                     else:
@@ -802,7 +802,7 @@ def fix_epub_titles_command(
                     log_error(f"Failed to process or fix titles in {epub_file_path}: {e}")
                     # For more detailed debugging, uncomment the next line
                     # log_debug(traceback.format_exc())
-    
+
     if not found_epub_files:
         log_warning(f"No .epub files found in '{abs_input_folder}' or its subdirectories.")
     else:

--- a/main.py
+++ b/main.py
@@ -764,8 +764,8 @@ def fix_epub_titles_command(
     input_folder: str = typer.Argument(..., help="Path to the folder containing EPUB files to fix. It will search recursively in subdirectories.")
 ):
     """
-    Scans a folder (and its subdirectories) for EPUB files and fixes missing <title>
-    tags in their internal XHTML components (chapters and cover).
+    Scans a folder (and its subdirectories) for EPUB files and fixes missing <title> 
+    tags in their internal XHTML components (chapters and cover). 
     This command overwrites the original EPUB files.
     """
     log_info(f"Starting EPUB title fixing process for folder: {input_folder}")
@@ -793,7 +793,7 @@ def fix_epub_titles_command(
                         # Define epub.write_epub options; {} means use defaults
                         # epub3_pages=False and toc_depth=2 were used in build_epubs_for_story
                         # Using {} should be fine for just saving modifications.
-                        epub.write_epub(epub_file_path, book, {})
+                        epub.write_epub(epub_file_path, book, {}) 
                         log_success(f"Successfully fixed titles and saved: {epub_file_path}")
                         fixed_count += 1
                     else:
@@ -802,7 +802,7 @@ def fix_epub_titles_command(
                     log_error(f"Failed to process or fix titles in {epub_file_path}: {e}")
                     # For more detailed debugging, uncomment the next line
                     # log_debug(traceback.format_exc())
-
+    
     if not found_epub_files:
         log_warning(f"No .epub files found in '{abs_input_folder}' or its subdirectories.")
     else:

--- a/tests/test_epub_fixer.py
+++ b/tests/test_epub_fixer.py
@@ -14,7 +14,7 @@ def create_basic_book():
     # Basic NAV document (NCX is usually added by ebooklib automatically on write)
     nav_doc = epub.EpubNav(uid='nav', file_name='nav.xhtml', title='Navigation')
     book.add_item(nav_doc)
-    book.spine = ['nav']
+    book.spine = ['nav'] 
     return book
 
 def test_fix_missing_titles():
@@ -36,7 +36,7 @@ def test_fix_missing_titles():
     chap_item2 = epub.EpubHtml(uid='c2', file_name='chap2.xhtml', title='None') # "None" should be overridden by filename
     chap_item2.content = '<html><head></head><body><h1>My Chapter 2</h1></body></html>'
     book.add_item(chap_item2)
-
+    
     # Chapter item with no item.title
     chap_item3 = epub.EpubHtml(uid='c3', file_name='chap_three_test.xhtml') # No item.title, should use filename
     chap_item3.content = '<html><head></head><body><h1>My Chapter 3</h1></body></html>'
@@ -44,7 +44,7 @@ def test_fix_missing_titles():
 
     # Update spine
     book.spine.extend([cover_item, chap_item1, chap_item2, chap_item3])
-
+    
     result = fix_xhtml_titles_in_epub(book)
     assert result is True, "fix_xhtml_titles_in_epub should return True as titles were modified"
 
@@ -72,7 +72,7 @@ def test_fix_missing_titles():
     assert chap2_soup.head is not None
     assert chap2_soup.head.title is not None
     assert chap2_soup.head.title.string == 'Chap2', "Chapter 2 title should be derived from filename 'chap2.xhtml'"
-
+    
     # Verify chapter 3 title (no item.title, uses filename)
     retrieved_chap3_item = book.get_item_with_id('c3')
     assert retrieved_chap3_item is not None
@@ -101,7 +101,7 @@ def test_titles_already_correct_and_some_needing_fix():
     chap_item2 = epub.EpubHtml(uid='c2', file_name='chap2.xhtml', title='Chapter Two Needs Fixing')
     chap_item2.content = '<html><head></head><body><h1>My Chapter 2</h1></body></html>' # No <title>
     book.add_item(chap_item2)
-
+    
     # Chapter item - Existing title is "None", should be fixed from filename
     chap_item3 = epub.EpubHtml(uid='c3', file_name='chap3_filename.xhtml', title='Another Chapter') # item.title is valid
     chap_item3.content = '<html><head><title>None</title></head><body><h1>My Chapter 3</h1></body></html>' # <title>None</title>
@@ -118,7 +118,7 @@ def test_titles_already_correct_and_some_needing_fix():
 
     chap1_soup = BeautifulSoup(book.get_item_with_id('c1').get_content().decode(), 'html.parser')
     assert chap1_soup.head.title.string == 'Chapter One'
-
+    
     chap2_soup = BeautifulSoup(book.get_item_with_id('c2').get_content().decode(), 'html.parser')
     assert chap2_soup.head.title.string == 'Chapter Two Needs Fixing' # Fixed from item.title
 
@@ -144,7 +144,7 @@ def test_no_changes_needed_all_correct():
     chap_item = epub.EpubHtml(uid='c1', file_name='chap1.xhtml', title='Chapter One')
     chap_item.content = '<html><head><title>Chapter One</title></head><body><h1>My Chapter</h1></body></html>'
     book.add_item(chap_item)
-
+    
     book.spine.extend([cover_item, chap_item])
 
     result = fix_xhtml_titles_in_epub(book)
@@ -168,7 +168,7 @@ def test_fix_item_with_no_head_tag():
     chap_no_head.content = '<html><body><h1>Chapter Lacking Head</h1></body></html>'
     book.add_item(chap_no_head)
     book.spine.append(chap_no_head)
-
+    
     result = fix_xhtml_titles_in_epub(book)
     assert result is True, "Should return True as item was modified to add head and title"
 
@@ -213,14 +213,14 @@ def test_non_html_item_is_skipped():
     book.add_item(css_item)
     # fix_xhtml_titles_in_epub filters by ITEM_DOCUMENT, so this might not even be seen.
     # If it did see it, it also filters by .xhtml/.html extension.
-
+    
     initial_content = css_item.get_content()
     result = fix_xhtml_titles_in_epub(book) # Should only process document items
-
+    
     # Assert that the function returns False if only non-HTML items or already correct HTML items are present
     # In this case, create_basic_book adds a nav.xhtml which *will* be processed.
     # So, let's check if this specific item was touched or if the result reflects changes elsewhere.
-
+    
     # To isolate, let's make a book with *only* a CSS item and see if it returns False
     isolated_book = epub.EpubBook()
     isolated_book.add_item(css_item)
@@ -234,7 +234,7 @@ def test_non_html_item_is_skipped():
     nav_doc.content = "<html><head></head><body><p>Nav content</p></body></html>" # No title tag
     book_with_nav_only.add_item(nav_doc)
     book_with_nav_only.spine = ['nav']
-
+    
     nav_result = fix_xhtml_titles_in_epub(book_with_nav_only)
     assert nav_result is True, "Should return True as nav.xhtml was modified"
     nav_soup = BeautifulSoup(book_with_nav_only.get_item_with_id('nav').get_content().decode(), 'html.parser')

--- a/tests/test_epub_fixer.py
+++ b/tests/test_epub_fixer.py
@@ -14,7 +14,7 @@ def create_basic_book():
     # Basic NAV document (NCX is usually added by ebooklib automatically on write)
     nav_doc = epub.EpubNav(uid='nav', file_name='nav.xhtml', title='Navigation')
     book.add_item(nav_doc)
-    book.spine = ['nav'] 
+    book.spine = ['nav']
     return book
 
 def test_fix_missing_titles():
@@ -36,7 +36,7 @@ def test_fix_missing_titles():
     chap_item2 = epub.EpubHtml(uid='c2', file_name='chap2.xhtml', title='None') # "None" should be overridden by filename
     chap_item2.content = '<html><head></head><body><h1>My Chapter 2</h1></body></html>'
     book.add_item(chap_item2)
-    
+
     # Chapter item with no item.title
     chap_item3 = epub.EpubHtml(uid='c3', file_name='chap_three_test.xhtml') # No item.title, should use filename
     chap_item3.content = '<html><head></head><body><h1>My Chapter 3</h1></body></html>'
@@ -44,7 +44,7 @@ def test_fix_missing_titles():
 
     # Update spine
     book.spine.extend([cover_item, chap_item1, chap_item2, chap_item3])
-    
+
     result = fix_xhtml_titles_in_epub(book)
     assert result is True, "fix_xhtml_titles_in_epub should return True as titles were modified"
 
@@ -72,7 +72,7 @@ def test_fix_missing_titles():
     assert chap2_soup.head is not None
     assert chap2_soup.head.title is not None
     assert chap2_soup.head.title.string == 'Chap2', "Chapter 2 title should be derived from filename 'chap2.xhtml'"
-    
+
     # Verify chapter 3 title (no item.title, uses filename)
     retrieved_chap3_item = book.get_item_with_id('c3')
     assert retrieved_chap3_item is not None
@@ -101,7 +101,7 @@ def test_titles_already_correct_and_some_needing_fix():
     chap_item2 = epub.EpubHtml(uid='c2', file_name='chap2.xhtml', title='Chapter Two Needs Fixing')
     chap_item2.content = '<html><head></head><body><h1>My Chapter 2</h1></body></html>' # No <title>
     book.add_item(chap_item2)
-    
+
     # Chapter item - Existing title is "None", should be fixed from filename
     chap_item3 = epub.EpubHtml(uid='c3', file_name='chap3_filename.xhtml', title='Another Chapter') # item.title is valid
     chap_item3.content = '<html><head><title>None</title></head><body><h1>My Chapter 3</h1></body></html>' # <title>None</title>
@@ -118,7 +118,7 @@ def test_titles_already_correct_and_some_needing_fix():
 
     chap1_soup = BeautifulSoup(book.get_item_with_id('c1').get_content().decode(), 'html.parser')
     assert chap1_soup.head.title.string == 'Chapter One'
-    
+
     chap2_soup = BeautifulSoup(book.get_item_with_id('c2').get_content().decode(), 'html.parser')
     assert chap2_soup.head.title.string == 'Chapter Two Needs Fixing' # Fixed from item.title
 
@@ -144,7 +144,7 @@ def test_no_changes_needed_all_correct():
     chap_item = epub.EpubHtml(uid='c1', file_name='chap1.xhtml', title='Chapter One')
     chap_item.content = '<html><head><title>Chapter One</title></head><body><h1>My Chapter</h1></body></html>'
     book.add_item(chap_item)
-    
+
     book.spine.extend([cover_item, chap_item])
 
     result = fix_xhtml_titles_in_epub(book)
@@ -168,7 +168,7 @@ def test_fix_item_with_no_head_tag():
     chap_no_head.content = '<html><body><h1>Chapter Lacking Head</h1></body></html>'
     book.add_item(chap_no_head)
     book.spine.append(chap_no_head)
-    
+
     result = fix_xhtml_titles_in_epub(book)
     assert result is True, "Should return True as item was modified to add head and title"
 
@@ -213,14 +213,14 @@ def test_non_html_item_is_skipped():
     book.add_item(css_item)
     # fix_xhtml_titles_in_epub filters by ITEM_DOCUMENT, so this might not even be seen.
     # If it did see it, it also filters by .xhtml/.html extension.
-    
+
     initial_content = css_item.get_content()
     result = fix_xhtml_titles_in_epub(book) # Should only process document items
-    
+
     # Assert that the function returns False if only non-HTML items or already correct HTML items are present
     # In this case, create_basic_book adds a nav.xhtml which *will* be processed.
     # So, let's check if this specific item was touched or if the result reflects changes elsewhere.
-    
+
     # To isolate, let's make a book with *only* a CSS item and see if it returns False
     isolated_book = epub.EpubBook()
     isolated_book.add_item(css_item)
@@ -234,7 +234,7 @@ def test_non_html_item_is_skipped():
     nav_doc.content = "<html><head></head><body><p>Nav content</p></body></html>" # No title tag
     book_with_nav_only.add_item(nav_doc)
     book_with_nav_only.spine = ['nav']
-    
+
     nav_result = fix_xhtml_titles_in_epub(book_with_nav_only)
     assert nav_result is True, "Should return True as nav.xhtml was modified"
     nav_soup = BeautifulSoup(book_with_nav_only.get_item_with_id('nav').get_content().decode(), 'html.parser')

--- a/tests/test_epub_fixer.py
+++ b/tests/test_epub_fixer.py
@@ -1,0 +1,242 @@
+# tests/test_epub_fixer.py
+import pytest
+from ebooklib import epub
+from bs4 import BeautifulSoup
+from core.epub_builder import fix_xhtml_titles_in_epub
+import os # Will be needed if we add tests that create temp files/dirs
+
+# Helper to create a basic EpubBook for tests
+def create_basic_book():
+    book = epub.EpubBook()
+    book.set_identifier("test_id_default")
+    book.set_title("Test Book Default")
+    book.set_language("en")
+    # Basic NAV document (NCX is usually added by ebooklib automatically on write)
+    nav_doc = epub.EpubNav(uid='nav', file_name='nav.xhtml', title='Navigation')
+    book.add_item(nav_doc)
+    book.spine = ['nav']
+    return book
+
+def test_fix_missing_titles():
+    book = create_basic_book()
+    book.set_identifier("test_id_missing")
+    book.set_title("Test Book Missing Titles")
+
+    # Cover item - uid='cover' and file_name='cover.xhtml' are important for detection
+    cover_item = epub.EpubHtml(uid='cover', file_name='cover.xhtml', title='Cover Page Item Should Be Ignored')
+    cover_item.content = '<html><head></head><body><p>Cover content here</p></body></html>'
+    book.add_item(cover_item)
+
+    # Chapter item with a good item.title
+    chap_item1 = epub.EpubHtml(uid='c1', file_name='chap1.xhtml', title='Chapter One Is Great')
+    chap_item1.content = '<html><head></head><body><h1>My Chapter 1</h1></body></html>'
+    book.add_item(chap_item1)
+
+    # Chapter item with an item.title that should be ignored (e.g., "None")
+    chap_item2 = epub.EpubHtml(uid='c2', file_name='chap2.xhtml', title='None') # "None" should be overridden by filename
+    chap_item2.content = '<html><head></head><body><h1>My Chapter 2</h1></body></html>'
+    book.add_item(chap_item2)
+
+    # Chapter item with no item.title
+    chap_item3 = epub.EpubHtml(uid='c3', file_name='chap_three_test.xhtml') # No item.title, should use filename
+    chap_item3.content = '<html><head></head><body><h1>My Chapter 3</h1></body></html>'
+    book.add_item(chap_item3)
+
+    # Update spine
+    book.spine.extend([cover_item, chap_item1, chap_item2, chap_item3])
+
+    result = fix_xhtml_titles_in_epub(book)
+    assert result is True, "fix_xhtml_titles_in_epub should return True as titles were modified"
+
+    # Verify cover title
+    # The fix_xhtml_titles_in_epub function prioritizes 'cover.xhtml' name for "Cover" title
+    retrieved_cover_item = book.get_item_with_id('cover')
+    assert retrieved_cover_item is not None, "Cover item should still exist"
+    cover_soup = BeautifulSoup(retrieved_cover_item.get_content().decode(), 'html.parser')
+    assert cover_soup.head is not None, "Cover item should have a <head> tag"
+    assert cover_soup.head.title is not None, "Cover item <head> should have a <title> tag"
+    assert cover_soup.head.title.string == 'Cover', "Cover title should be 'Cover'"
+
+    # Verify chapter 1 title (uses item.title)
+    retrieved_chap1_item = book.get_item_with_id('c1')
+    assert retrieved_chap1_item is not None
+    chap1_soup = BeautifulSoup(retrieved_chap1_item.get_content().decode(), 'html.parser')
+    assert chap1_soup.head is not None
+    assert chap1_soup.head.title is not None
+    assert chap1_soup.head.title.string == 'Chapter One Is Great', "Chapter 1 title should be from item.title"
+
+    # Verify chapter 2 title (item.title was 'None', so uses filename)
+    retrieved_chap2_item = book.get_item_with_id('c2')
+    assert retrieved_chap2_item is not None
+    chap2_soup = BeautifulSoup(retrieved_chap2_item.get_content().decode(), 'html.parser')
+    assert chap2_soup.head is not None
+    assert chap2_soup.head.title is not None
+    assert chap2_soup.head.title.string == 'Chap2', "Chapter 2 title should be derived from filename 'chap2.xhtml'"
+
+    # Verify chapter 3 title (no item.title, uses filename)
+    retrieved_chap3_item = book.get_item_with_id('c3')
+    assert retrieved_chap3_item is not None
+    chap3_soup = BeautifulSoup(retrieved_chap3_item.get_content().decode(), 'html.parser')
+    assert chap3_soup.head is not None
+    assert chap3_soup.head.title is not None
+    assert chap3_soup.head.title.string == 'Chap Three Test', "Chapter 3 title should be derived from filename 'chap_three_test.xhtml'"
+
+
+def test_titles_already_correct_and_some_needing_fix():
+    book = create_basic_book()
+    book.set_identifier("test_id_mixed")
+    book.set_title("Test Book Mixed Titles")
+
+    # Cover item - Correct
+    cover_item = epub.EpubHtml(uid='cover', file_name='cover.xhtml', title='Irrelevant Item Title')
+    cover_item.content = '<html><head><title>Cover</title></head><body><p>Cover content</p></body></html>'
+    book.add_item(cover_item)
+
+    # Chapter item - Correct
+    chap_item1 = epub.EpubHtml(uid='c1', file_name='chap1.xhtml', title='Chapter One')
+    chap_item1.content = '<html><head><title>Chapter One</title></head><body><h1>My Chapter</h1></body></html>'
+    book.add_item(chap_item1)
+
+    # Chapter item - Missing title, but item.title is valid
+    chap_item2 = epub.EpubHtml(uid='c2', file_name='chap2.xhtml', title='Chapter Two Needs Fixing')
+    chap_item2.content = '<html><head></head><body><h1>My Chapter 2</h1></body></html>' # No <title>
+    book.add_item(chap_item2)
+
+    # Chapter item - Existing title is "None", should be fixed from filename
+    chap_item3 = epub.EpubHtml(uid='c3', file_name='chap3_filename.xhtml', title='Another Chapter') # item.title is valid
+    chap_item3.content = '<html><head><title>None</title></head><body><h1>My Chapter 3</h1></body></html>' # <title>None</title>
+    book.add_item(chap_item3)
+
+    book.spine.extend([cover_item, chap_item1, chap_item2, chap_item3])
+
+    result = fix_xhtml_titles_in_epub(book)
+    assert result is True, "Should return True as chap2 and chap3 were modified"
+
+    # Verify titles
+    cover_soup = BeautifulSoup(book.get_item_with_id('cover').get_content().decode(), 'html.parser')
+    assert cover_soup.head.title.string == 'Cover'
+
+    chap1_soup = BeautifulSoup(book.get_item_with_id('c1').get_content().decode(), 'html.parser')
+    assert chap1_soup.head.title.string == 'Chapter One'
+
+    chap2_soup = BeautifulSoup(book.get_item_with_id('c2').get_content().decode(), 'html.parser')
+    assert chap2_soup.head.title.string == 'Chapter Two Needs Fixing' # Fixed from item.title
+
+    # For chap_item3, the item.title is 'Another Chapter'.
+    # The logic in fix_xhtml_titles_in_epub is: if title_tag.string != desired_title_text, it updates.
+    # desired_title_text for chap_item3 will be 'Another Chapter' (from item.title).
+    # So, <title>None</title> should be changed to <title>Another Chapter</title>.
+    chap3_soup = BeautifulSoup(book.get_item_with_id('c3').get_content().decode(), 'html.parser')
+    assert chap3_soup.head.title.string == 'Another Chapter'
+
+
+def test_no_changes_needed_all_correct():
+    book = create_basic_book()
+    book.set_identifier("test_id_all_correct")
+    book.set_title("Test Book All Correct")
+
+    # Cover item
+    cover_item = epub.EpubHtml(uid='cover', file_name='cover.xhtml', title='Cover') # item.title is ignored due to filename
+    cover_item.content = '<html><head><title>Cover</title></head><body><p>Cover content</p></body></html>'
+    book.add_item(cover_item)
+
+    # Chapter item
+    chap_item = epub.EpubHtml(uid='c1', file_name='chap1.xhtml', title='Chapter One')
+    chap_item.content = '<html><head><title>Chapter One</title></head><body><h1>My Chapter</h1></body></html>'
+    book.add_item(chap_item)
+
+    book.spine.extend([cover_item, chap_item])
+
+    result = fix_xhtml_titles_in_epub(book)
+    assert result is False, "fix_xhtml_titles_in_epub should return False as no titles needed modification"
+
+    # Verify titles remain unchanged
+    cover_soup = BeautifulSoup(book.get_item_with_id('cover').get_content().decode(), 'html.parser')
+    assert cover_soup.head.title.string == 'Cover'
+
+    chap_soup = BeautifulSoup(book.get_item_with_id('c1').get_content().decode(), 'html.parser')
+    assert chap_soup.head.title.string == 'Chapter One'
+
+def test_fix_item_with_no_head_tag():
+    book = create_basic_book()
+    book.set_identifier("test_id_no_head")
+    book.set_title("Test Book No Head")
+
+    # Chapter item with no <head> at all
+    chap_no_head = epub.EpubHtml(uid='c_no_head', file_name='chap_no_head.xhtml', title='No Head Chapter')
+    # Content is just an html tag with a body. The fixer should create a head and title.
+    chap_no_head.content = '<html><body><h1>Chapter Lacking Head</h1></body></html>'
+    book.add_item(chap_no_head)
+    book.spine.append(chap_no_head)
+
+    result = fix_xhtml_titles_in_epub(book)
+    assert result is True, "Should return True as item was modified to add head and title"
+
+    retrieved_item_soup = BeautifulSoup(book.get_item_with_id('c_no_head').get_content().decode(), 'html.parser')
+    assert retrieved_item_soup.html is not None, "HTML tag should exist"
+    assert retrieved_item_soup.head is not None, "<head> tag should have been created"
+    assert retrieved_item_soup.head.title is not None, "<title> tag should have been created in new head"
+    assert retrieved_item_soup.head.title.string == 'No Head Chapter', "Title should be from item.title"
+
+def test_fix_item_with_no_html_or_head_tag_fragment():
+    book = create_basic_book()
+    # This tests how the fixer handles a content fragment (though EPUB items should ideally be full docs)
+    # The fixer has a basic mechanism to wrap content if no <html> tag is found.
+
+    chap_fragment = epub.EpubHtml(uid='c_fragment', file_name='chap_fragment.xhtml', title='Fragment Chapter')
+    chap_fragment.content = '<body><h1>Just a body</h1></body>' # Not even an <html> tag
+    book.add_item(chap_fragment)
+    book.spine.append(chap_fragment)
+
+    result = fix_xhtml_titles_in_epub(book)
+    assert result is True
+
+    retrieved_item_soup = BeautifulSoup(book.get_item_with_id('c_fragment').get_content().decode(), 'html.parser')
+    # Check the structure that fix_xhtml_titles_in_epub is expected to create
+    assert retrieved_item_soup.html is not None, "An <html> tag should have been created by the fixer"
+    assert retrieved_item_soup.head is not None, "<head> should have been created"
+    assert retrieved_item_soup.head.title is not None, "<title> should be in the created <head>"
+    assert retrieved_item_soup.head.title.string == 'Fragment Chapter'
+    assert retrieved_item_soup.body is not None, "A <body> tag should exist (either original or created)"
+    assert retrieved_item_soup.body.h1 is not None, "Original content (h1) should be within a body"
+    assert retrieved_item_soup.body.h1.string == 'Just a body'
+
+# Consider adding tests for XHTML files not ending in .xhtml/.html (should be skipped by the function)
+# Consider adding tests for items where item.title is an empty string or whitespace (should use filename)
+# Consider a test for when filename generation results in an empty string (should use "Untitled Document")
+# (The current implementation of filename processing in fix_xhtml_titles_in_epub seems robust enough for most cases)
+
+# Example of an item that should be skipped by the title fixer (e.g. CSS or image)
+def test_non_html_item_is_skipped():
+    book = create_basic_book()
+    css_item = epub.EpubItem(uid="style_default", file_name="style/default.css", media_type="text/css", content=b"body {color: red;}")
+    book.add_item(css_item)
+    # fix_xhtml_titles_in_epub filters by ITEM_DOCUMENT, so this might not even be seen.
+    # If it did see it, it also filters by .xhtml/.html extension.
+
+    initial_content = css_item.get_content()
+    result = fix_xhtml_titles_in_epub(book) # Should only process document items
+
+    # Assert that the function returns False if only non-HTML items or already correct HTML items are present
+    # In this case, create_basic_book adds a nav.xhtml which *will* be processed.
+    # So, let's check if this specific item was touched or if the result reflects changes elsewhere.
+
+    # To isolate, let's make a book with *only* a CSS item and see if it returns False
+    isolated_book = epub.EpubBook()
+    isolated_book.add_item(css_item)
+    isolated_result = fix_xhtml_titles_in_epub(isolated_book)
+    assert isolated_result is False, "Should return False as no applicable items were modified"
+    assert css_item.get_content() == initial_content, "Non-HTML/XHTML item content should not be changed"
+
+    # Test with a nav file that needs a title
+    book_with_nav_only = epub.EpubBook()
+    nav_doc = epub.EpubNav(uid='nav', file_name='nav.xhtml', title='Navigation') # item.title is "Navigation"
+    nav_doc.content = "<html><head></head><body><p>Nav content</p></body></html>" # No title tag
+    book_with_nav_only.add_item(nav_doc)
+    book_with_nav_only.spine = ['nav']
+
+    nav_result = fix_xhtml_titles_in_epub(book_with_nav_only)
+    assert nav_result is True, "Should return True as nav.xhtml was modified"
+    nav_soup = BeautifulSoup(book_with_nav_only.get_item_with_id('nav').get_content().decode(), 'html.parser')
+    assert nav_soup.head.title is not None
+    assert nav_soup.head.title.string == 'Navigation'


### PR DESCRIPTION
I resolved epubcheck warnings (RSC-017) related to missing <title> elements in XHTML files within generated EPUBs.

- I modified `_load_chapter_content` in `core/epub_builder.py` to parse chapter HTML content and insert a <title> tag (using the chapter's title) into the <head> if not present.
- I updated `build_epubs_for_story` in `core/epub_builder.py` to find `cover.xhtml` after its creation by `ebooklib` and set its <title> to "Cover".